### PR TITLE
Add S3 backend for TF state

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket = "pkanellidis-awendt-terraform-s3-backend"
+    key    = "mentee-app.infrastructure/terraform.tfstate"
+    region = "eu-west-1"
+
+    profile = "sandbox"
+  }
+}


### PR DESCRIPTION
Fixes #7. When you're ready to migrate the state, run `terraform init -migrate-state` on your local machine.